### PR TITLE
Fix SyntaxError due to invalid module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ export default function relativeImages() {
 
     function transformUrl(url) {
       if (url.startsWith(".")) {
-        let camel = toCamel(url);
+        // filenames can start with digits,
+        // prepend underscore to guarantee valid module name
+        let camel = `_${toCamel(url)}`;
         const count = url_count.get(camel);
         const dupe = urls.get(url);
 


### PR DESCRIPTION
- There is a SyntaxError thrown when relative image filename starts with a digit or a character that is not valid as module name.
- Fix by prepending module name with an underscore which guarantees that the module name for import will always be valid.