### PR TITLE
New Feature: support sites hosted in a sub-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ export default config;
 ```
 
 ### Option 2: Add to mdsvex.config.js
+
 If you're using it as a standalone, then you can pass it to mdsvex like this:
 
 ```js
@@ -43,6 +44,7 @@ mdsvex({
 ```
 
 ### Advanced Configuration
+
 If your site is hosted in a sub-folder ( for example in github pages ), you can supply a basePath option to prepend paths:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If your site is hosted in a sub-folder ( for example in github pages ), you can 
 // svelte.config.js
 import relativeImages from "mdsvex-relative-images";
 
-const basePath = process.env.PAGES_BASE || '/'
+const basePath = process.env.PAGES_BASE || ''
 
 const config = {
   // ...

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ mdsvex({
 });
 ```
 
+### Advanced Configuration
+If your site is hosted in a sub-folder ( for example in github pages ), you can supply a basePath option to prepend paths:
+
+```js
+// svelte.config.js
+import relativeImages from "mdsvex-relative-images";
+
+const basePath = process.env.PAGES_BASE || '/'
+
+const config = {
+  // ...
+  preprocess: [ // ...
+    mdsvex({ remarkPlugins: [[relativeImages, {basePath}]] })
+  ],
+  // ...
+  extensions: [".svelte", ".svx"],
+};
+
+export default config;
+```
+
 ## 🚀 Usage
 
 ### Markdown Syntax

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const RE_SCRIPT_START =
 const RE_PROPS = /(\w+)\s*=\s*(["'])(\s*(\$\w+|\.{1,2})[\/\\].*?\.\w+\s*(\?([^=&]+=[^=&]+)(&[^=&]+=[^=&]+)*)?)\2/g;
 const RE_PATH = /\s*(\$\w+|\.{1,2})[\/\\].*?\.\w+\s*(\?([^=&]+=[^=&]+)(&[^=&]+=[^=&]+)*)?/;
 
-export default function relativeImages() {
+export default function relativeImages(options = {basePath: '/'}) {
     return function transformer(tree) {
         const urls = new Map();
         const url_count = new Map();
@@ -38,6 +38,12 @@ export default function relativeImages() {
                 });
 
                 return `{${camel}}`;
+            }
+
+            // if the url starts with a slash, prepend the basePath
+            if (url.startsWith('/')) {
+                // basePath is in the format '/basePath/' so we need to slice the leading slash from the url
+                url = `${options.basePath}${url.slice(1)}`;
             }
 
             return url;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,12 @@ const RE_SCRIPT_START =
 const RE_PROPS = /(\w+)\s*=\s*(["'])(\s*(\$\w+|\.{1,2})[\/\\].*?\.\w+\s*(\?([^=&]+=[^=&]+)(&[^=&]+=[^=&]+)*)?)\2/g;
 const RE_PATH = /\s*(\$\w+|\.{1,2})[\/\\].*?\.\w+\s*(\?([^=&]+=[^=&]+)(&[^=&]+=[^=&]+)*)?/;
 
-export default function relativeImages(options = {basePath: '/'}) {
+/**
+ * @param {object} options
+ * @param {string} options.basePath - The base path to prepend to relative URLs. DO NOT INCLUDE '/' chars!
+ * @returns {function} A transformer function for processing the AST.
+ */
+export default function relativeImages(options = {basePath: ''}) {
     return function transformer(tree) {
         const urls = new Map();
         const url_count = new Map();
@@ -43,7 +48,7 @@ export default function relativeImages(options = {basePath: '/'}) {
             // if the url starts with a slash, prepend the basePath
             if (url.startsWith('/')) {
                 // basePath is in the format '/basePath/' so we need to slice the leading slash from the url
-                url = `${options.basePath}${url.slice(1)}`;
+                url = `/${options.basePath}/${url.slice(1)}`;
             }
 
             return url;


### PR DESCRIPTION
This adds an optional configuration to support sites hosted in a sub-directory ( for example gh pages ). This pull request includes a minimal implementation plus an updated to the README that documents the new option.